### PR TITLE
Fix motor name handling

### DIFF
--- a/robot_controller.py
+++ b/robot_controller.py
@@ -74,7 +74,10 @@ class RobotController:
     ELBOW_OFFSET_ANGLE_RAD = math.asin(robot_config.ELBOW_MOUNT_OFFSET_MM / L2)
 
     def __init__(self, update_goal_pos: bool = True):
-        self.motor_names = list(robot_config.motors.keys())
+        # Store motor names as a tuple so they can be safely used as dictionary
+        # keys inside the motors bus (lists are unhashable).  Passing a tuple is
+        # also supported by the underlying bus implementation.
+        self.motor_names = tuple(robot_config.motors.keys())
 
         self.current_positions_deg: Dict[str, float] = {}
         self.current_cartesian_mm: Dict[str, float] = {"x": 0.0, "z": 0.0}


### PR DESCRIPTION
## Summary
- switch `RobotController.motor_names` to tuple for hashability

## Testing
- `python3 check_positions.py --rate 0.1` *(fails to connect to hardware but no tuple error)*

------
https://chatgpt.com/codex/tasks/task_e_6855cda40f548331a906bb350217c9da